### PR TITLE
Fix: Netbeans Compile on Save does not load the correct Resources dir

### DIFF
--- a/static-mustache/src/main/java/com/github/sviperll/staticmustache/FileAdapter.java
+++ b/static-mustache/src/main/java/com/github/sviperll/staticmustache/FileAdapter.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright (c) 2014, Victor Nazarov <asviraspossible@gmail.com>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ *  1. Redistributions of source code must retain the above copyright notice,
+ *     this list of conditions and the following disclaimer.
+ *
+ *  2. Redistributions in binary form must reproduce the above copyright notice,
+ *     this list of conditions and the following disclaimer in the documentation and/or
+ *     other materials provided with the distribution.
+ *
+ *  3. Neither the name of the copyright holder nor the names of its contributors
+ *     may be used to endorse or promote products derived from this software
+ *     without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ *  ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ *  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ *  IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ *  ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ *  (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *   LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ *  ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ *  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+ *  EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.github.sviperll.staticmustache;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.FileReader;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.io.Reader;
+import java.io.Writer;
+import java.net.URI;
+import javax.tools.FileObject;
+
+/**
+ * This class wraps a java.io.File and makes it compatible to the
+ * javax.tools.FileObject
+ *
+ * @author Thomas Oster <thomas.oster@upstart-it.de>
+ */
+public class FileAdapter implements FileObject {
+
+    private final File f;
+
+    public FileAdapter(File f) {
+        this.f = f;
+    }
+
+    @Override
+    public URI toUri() {
+        return f.toURI();
+    }
+
+    @Override
+    public String getName() {
+        return f.getName();
+    }
+
+    @Override
+    public InputStream openInputStream() throws IOException {
+        return new FileInputStream(f);
+    }
+
+    @Override
+    public OutputStream openOutputStream() throws IOException {
+        return new FileOutputStream(f);
+    }
+
+    @Override
+    public Reader openReader(boolean bln) throws IOException {
+        return new FileReader(f);
+    }
+
+    @Override
+    public CharSequence getCharContent(boolean bln) throws IOException {
+        throw new UnsupportedOperationException("Not supported yet.");
+    }
+
+    @Override
+    public Writer openWriter() throws IOException {
+        return new FileWriter(f);
+    }
+
+    @Override
+    public long getLastModified() {
+        return f.lastModified();
+    }
+
+    @Override
+    public boolean delete() {
+        return f.delete();
+    }
+}

--- a/static-mustache/src/main/java/com/github/sviperll/staticmustache/GenerateRenderableAdapterProcessor.java
+++ b/static-mustache/src/main/java/com/github/sviperll/staticmustache/GenerateRenderableAdapterProcessor.java
@@ -41,6 +41,7 @@ import com.github.sviperll.staticmustache.context.VariableContext;
 import com.github.sviperll.meta.TextFormat;
 import com.github.sviperll.text.Layoutable;
 import com.github.sviperll.text.RendererDefinition;
+import java.io.File;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.io.OutputStreamWriter;
@@ -209,6 +210,14 @@ public class GenerateRenderableAdapterProcessor extends AbstractProcessor {
             SwitchablePrintWriter switchablePrintWriter = SwitchablePrintWriter.createInstance(stringWriter);
             try {
                 FileObject templateBinaryResource = processingEnv.getFiler().getResource(StandardLocation.CLASS_OUTPUT, "", templatePath);
+                //On some environments (e.g. NetBeans with compile on save) this won't resolve the correct path
+                //thus we try another route
+                if (!new File(templateBinaryResource.toUri()).exists()) {
+                    File abs = new File(GenerateRenderableAdapterProcessor.class.getClassLoader().getResource(templatePath).getFile());
+                    if (abs.exists()) {
+                        templateBinaryResource = new FileAdapter(abs);
+                    }
+                }
                 TextFileObject templateResource = new TextFileObject(templateBinaryResource, templateCharset, templatePath);
                 JavaLanguageModel javaModel = JavaLanguageModel.createInstance(processingEnv.getTypeUtils(), processingEnv.getElementUtils());
                 RenderingCodeGenerator codeGenerator = RenderingCodeGenerator.createInstance(javaModel, templateFormatElement);


### PR DESCRIPTION
Hi,
if you use this library with NetBeans and have Compile on Save active, the template file's won't be found (FileNotFoundException). This is because during annotation processing the `StandardLocation.CLASS_OUTPUT` does not work correctly (see https://stackoverflow.com/questions/25192381/how-can-i-get-the-working-directory-of-a-project-from-an-annotation-processor-in?rq=1).

I just implemented a workaround which works at least for me. This should not break anything, because it just tries another path if the current one fails and also only replaced the path if the newly tried on succeeds.